### PR TITLE
WP7 hardening: thisismyurl-revision-reaper (v1.6148.2110)

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -63,7 +63,9 @@
 				nonce: nonce
 			} ).done( function ( res ) {
 				completed++;
-				$( '#rr-progress-bar' ).css( 'width', Math.round( ( completed / total ) * 100 ) + '%' );
+				var percent = Math.round( ( completed / total ) * 100 );
+				// Keep the visual width and the assistive-tech value in lockstep.
+				$( '#rr-progress-bar' ).css( 'width', percent + '%' ).attr( 'aria-valuenow', percent );
 				$( '#rr-log' ).prepend( '<div>' + ( res && res.data ? res.data : '' ) + '</div>' );
 				processNext();
 			} );

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * WP 7 Abilities API registration for This Is My URL - Revision Reaper.
+ *
+ * Exposes the plugin's database-cleanup pass (revisions, trashed posts,
+ * spam comments, expired transients, table optimization) as a discoverable,
+ * REST/AI-invokable ability that returns per-category counts and ROI.
+ *
+ * @package Thisismyurl_Revision_Reaper
+ * @since   1.6147
+ */
+
+declare( strict_types = 1 );
+
+defined( 'ABSPATH' ) || exit;
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return; // Abilities API unavailable (WordPress < 6.9).
+		}
+
+		wp_register_ability(
+			'thisismyurl-revision-reaper/clean',
+			array(
+				'label'               => __( 'Run database cleanup', 'thisismyurl-revision-reaper' ),
+				'description'         => __( 'Reaps surplus post revisions, purges aged trashed posts, trashes spam comments, deletes expired transients, and optimizes database tables, returning per-category counts and bytes reclaimed. Trashed posts are only purged once older than EMPTY_TRASH_DAYS and a JSON snapshot is written before any row is removed. Use dry_run to preview the would-clean counts without deleting anything.', 'thisismyurl-revision-reaper' ),
+				'category'            => 'site',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'revisions'        => array(
+							'type'        => 'boolean',
+							'description' => __( 'Reap post revisions beyond the keep limit. Defaults to true.', 'thisismyurl-revision-reaper' ),
+						),
+						'trashed_posts'    => array(
+							'type'        => 'boolean',
+							'description' => __( 'Purge trashed posts that have aged past EMPTY_TRASH_DAYS. Defaults to the saved auto-trash option.', 'thisismyurl-revision-reaper' ),
+						),
+						'spam_comments'    => array(
+							'type'        => 'boolean',
+							'description' => __( 'Move spam comments to the comment trash. Defaults to the saved auto-spam option.', 'thisismyurl-revision-reaper' ),
+						),
+						'limit'            => array(
+							'type'        => 'integer',
+							'minimum'     => 0,
+							'description' => __( 'Number of recent revisions to keep per post. Defaults to the saved option (3 if unset).', 'thisismyurl-revision-reaper' ),
+						),
+						'max_items'        => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Hard cap on the number of eligible items processed in this pass. Defaults to 1000.', 'thisismyurl-revision-reaper' ),
+						),
+						'dry_run'          => array(
+							'type'        => 'boolean',
+							'description' => __( 'Preview the would-clean counts without deleting anything. Defaults to false.', 'thisismyurl-revision-reaper' ),
+						),
+					),
+					'additionalProperties' => false,
+					'default'              => array(),
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'required'             => array( 'dry_run', 'revisions', 'trashed_posts', 'trash_skipped', 'spam_comments', 'transients', 'tables', 'bytes_freed', 'bytes_freed_human' ),
+					'properties'           => array(
+						'dry_run'           => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether this was a preview run that deleted nothing.', 'thisismyurl-revision-reaper' ),
+						),
+						'revisions'         => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of posts whose surplus revisions were reaped.', 'thisismyurl-revision-reaper' ),
+						),
+						'trashed_posts'     => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of trashed posts purged (aged past EMPTY_TRASH_DAYS).', 'thisismyurl-revision-reaper' ),
+						),
+						'trash_skipped'     => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of trashed posts skipped because they were not yet old enough to purge.', 'thisismyurl-revision-reaper' ),
+						),
+						'spam_comments'     => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of spam comments moved to the comment trash.', 'thisismyurl-revision-reaper' ),
+						),
+						'transients'        => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of expired transient pairs removed (or eligible, on a dry run).', 'thisismyurl-revision-reaper' ),
+						),
+						'tables'            => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of database tables optimized (always 0 on a dry run).', 'thisismyurl-revision-reaper' ),
+						),
+						'bytes_freed'       => array(
+							'type'        => 'integer',
+							'description' => __( 'Bytes reclaimed from reaped revision rows.', 'thisismyurl-revision-reaper' ),
+						),
+						'bytes_freed_human' => array(
+							'type'        => 'string',
+							'description' => __( 'Human-readable size of the reclaimed bytes, e.g. "1.4 MB".', 'thisismyurl-revision-reaper' ),
+						),
+						'export'            => array(
+							'type'        => 'string',
+							'description' => __( 'Filename of the pre-run JSON snapshot, or an empty string when none was written.', 'thisismyurl-revision-reaper' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => static function ( $input = array() ) {
+					if ( ! class_exists( 'TIMU_Revision_Reaper' ) ) {
+						return new WP_Error(
+							'timu_rr_unavailable',
+							__( 'Revision Reaper is not available.', 'thisismyurl-revision-reaper' )
+						);
+					}
+
+					$input = is_array( $input ) ? $input : array();
+
+					$settings = array(
+						'limit'             => isset( $input['limit'] )
+							? max( 0, (int) $input['limit'] )
+							: (int) get_option( 'timu_rr_limit', 3 ),
+						'include_revisions' => ! array_key_exists( 'revisions', $input ) || ! empty( $input['revisions'] ),
+						'include_trash'     => array_key_exists( 'trashed_posts', $input )
+							? ( ! empty( $input['trashed_posts'] ) ? 1 : 0 )
+							: (int) get_option( 'timu_rr_auto_trash', 0 ),
+						'include_spam'      => array_key_exists( 'spam_comments', $input )
+							? ( ! empty( $input['spam_comments'] ) ? 1 : 0 )
+							: (int) get_option( 'timu_rr_auto_spam', 0 ),
+					);
+
+					$caps = array();
+					if ( isset( $input['max_items'] ) ) {
+						$caps['max_items'] = max( 1, (int) $input['max_items'] );
+					}
+
+					$dry_run = ! empty( $input['dry_run'] );
+
+					$report = TIMU_Revision_Reaper::run_cleanup( $settings, $caps, $dry_run );
+
+					return array(
+						'dry_run'           => (bool) $report['dry_run'],
+						'revisions'         => (int) $report['revisions'],
+						'trashed_posts'     => (int) $report['trashed_posts'],
+						'trash_skipped'     => (int) $report['trash_skipped'],
+						'spam_comments'     => (int) $report['spam_comments'],
+						'transients'        => (int) $report['transients'],
+						'tables'            => (int) $report['tables'],
+						'bytes_freed'       => (int) $report['bytes_freed'],
+						'bytes_freed_human' => size_format( (int) $report['bytes_freed'] ) ?: '0 B',
+						'export'            => '' !== $report['export'] ? wp_basename( $report['export'] ) : '',
+					);
+				},
+				'permission_callback' => static function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+);

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -7,7 +7,7 @@
  * REST/AI-invokable ability that returns per-category counts and ROI.
  *
  * @package Thisismyurl_Revision_Reaper
- * @since   1.6147
+ * @since   1.6148
  */
 
 declare( strict_types = 1 );

--- a/includes/class-exporter.php
+++ b/includes/class-exporter.php
@@ -3,14 +3,20 @@
  * Pre-delete export for Revision Reaper.
  *
  * Writes a JSON snapshot of the rows we are about to remove (revisions and
- * comments) into the uploads directory before any destructive call runs.
- * Acts as a poor-man's restore source: the user can re-insert manually if
- * they regret a run, and we don't bury the data behind a paywall.
+ * comments) before any destructive call runs. Acts as a poor-man's restore
+ * source: the user can re-insert manually if they regret a run, and we don't
+ * bury the data behind a paywall.
  *
- * Storage layout:
- *   uploads/revision-reaper/exports/<timestamp>-<uniqid>.json
- *   uploads/revision-reaper/exports/.htaccess  (deny-all for Apache)
- *   uploads/revision-reaper/exports/index.php  (silence is golden)
+ * Storage: each snapshot is a single non-autoloaded option named
+ * `timu_rr_export_<token>`, plus a registry option `timu_rr_export_index`
+ * that tracks the snapshot tokens and their timestamps for retention.
+ *
+ * The snapshot rows can include comment PII (author email, author IP), so the
+ * data is deliberately kept inside the database rather than on disk. A file in
+ * `wp-content/uploads/` is web-root on every server and the deny-all `.htaccess`
+ * that previously guarded it is inert on nginx, so a guessable filename could
+ * expose the PII snapshot to an unauthenticated request. The options table is
+ * never web-served, so the snapshot is unreachable regardless of web server.
  *
  * Retention: exports older than 30 days are pruned at the start of each run.
  *
@@ -27,56 +33,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 class TIMU_Revision_Reaper_Exporter {
 
 	const RETENTION_DAYS = 30;
-	const SUBDIR         = 'revision-reaper/exports';
 
 	/**
-	 * Returns the absolute path to the exports directory, creating it
-	 * (with deny-all guards) on first call. Returns false on failure.
-	 *
-	 * @return string|false
+	 * Option-name prefix for an individual snapshot.
 	 */
-	public static function get_export_dir() {
-		$uploads = wp_upload_dir( null, false );
-		if ( empty( $uploads['basedir'] ) || ! empty( $uploads['error'] ) ) {
-			return false;
-		}
-
-		$dir = trailingslashit( $uploads['basedir'] ) . self::SUBDIR;
-		if ( ! wp_mkdir_p( $dir ) ) {
-			return false;
-		}
-
-		// Guards. Idempotent — only written once.
-		$htaccess = trailingslashit( $dir ) . '.htaccess';
-		if ( ! file_exists( $htaccess ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			@file_put_contents( $htaccess, "Require all denied\nDeny from all\n" );
-		}
-
-		$index = trailingslashit( $dir ) . 'index.php';
-		if ( ! file_exists( $index ) ) {
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			@file_put_contents( $index, "<?php // Silence is golden.\n" );
-		}
-
-		return $dir;
-	}
+	const OPTION_PREFIX = 'timu_rr_export_';
 
 	/**
-	 * Snapshot the supplied work list to a JSON file. Returns the absolute
-	 * file path on success, or false on failure.
+	 * Option holding the snapshot registry: token => unix timestamp.
+	 */
+	const INDEX_OPTION = 'timu_rr_export_index';
+
+	/**
+	 * Snapshot the supplied work list to a non-autoloaded option. Returns an
+	 * opaque handle (the snapshot's option name) on success, or false on
+	 * failure.
 	 *
-	 * @param array $items   List of { id, type } pairs that the worker will process.
-	 * @param int   $limit   Revisions-to-keep value used for the run.
+	 * The handle is suitable for display to the operator and is what the
+	 * run report, the WP-CLI command, and the AJAX pre-run check echo back.
+	 *
+	 * @param array $items List of { id, type } pairs that the worker will process.
+	 * @param int   $limit Revisions-to-keep value used for the run.
 	 * @return string|false
 	 */
 	public static function snapshot_before_run( array $items, $limit ) {
-		$dir = self::get_export_dir();
-		if ( false === $dir ) {
-			return false;
-		}
-
-		self::prune_old_exports( $dir );
+		self::prune_old_exports();
 
 		$payload = array(
 			'meta'  => array(
@@ -90,17 +71,38 @@ class TIMU_Revision_Reaper_Exporter {
 			'items' => self::expand_items_for_export( $items, (int) $limit ),
 		);
 
-		$file = trailingslashit( $dir ) . gmdate( 'Y-m-d_His' ) . '-' . wp_generate_password( 8, false, false ) . '.json';
 		$json = wp_json_encode( $payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-
 		if ( false === $json ) {
 			return false;
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		$ok = @file_put_contents( $file, $json );
+		$token       = gmdate( 'Y-m-d_His' ) . '-' . wp_generate_password( 8, false, false );
+		$option_name = self::OPTION_PREFIX . $token;
 
-		return $ok ? $file : false;
+		// Snapshots can hold comment PII and are read only on a manual restore,
+		// so they must never be autoloaded into memory on every request.
+		if ( ! add_option( $option_name, $json, '', false ) ) {
+			return false;
+		}
+
+		self::register_snapshot( $token );
+
+		return $option_name;
+	}
+
+	/**
+	 * Record a snapshot token and its creation time in the registry.
+	 *
+	 * @param string $token Snapshot token (the part after OPTION_PREFIX).
+	 * @return void
+	 */
+	private static function register_snapshot( $token ) {
+		$index = get_option( self::INDEX_OPTION, array() );
+		if ( ! is_array( $index ) ) {
+			$index = array();
+		}
+		$index[ $token ] = time();
+		update_option( self::INDEX_OPTION, $index, false );
 	}
 
 	/**
@@ -202,22 +204,31 @@ class TIMU_Revision_Reaper_Exporter {
 	}
 
 	/**
-	 * Delete export files older than RETENTION_DAYS days.
+	 * Delete snapshot options older than RETENTION_DAYS days and drop their
+	 * registry entries. Also reaps registry entries whose option has already
+	 * been removed by hand, keeping the index honest.
 	 *
-	 * @param string $dir Absolute directory path.
 	 * @return void
 	 */
-	public static function prune_old_exports( $dir ) {
-		$cutoff = time() - ( self::RETENTION_DAYS * DAY_IN_SECONDS );
-		$glob   = glob( trailingslashit( $dir ) . '*.json' );
-		if ( empty( $glob ) ) {
+	public static function prune_old_exports() {
+		$index = get_option( self::INDEX_OPTION, array() );
+		if ( ! is_array( $index ) || empty( $index ) ) {
 			return;
 		}
-		foreach ( $glob as $file ) {
-			$mtime = @filemtime( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors
-			if ( false !== $mtime && $mtime < $cutoff ) {
-				@unlink( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors,WordPress.WP.AlternativeFunctions.unlink_unlink
+
+		$cutoff  = time() - ( self::RETENTION_DAYS * DAY_IN_SECONDS );
+		$changed = false;
+
+		foreach ( $index as $token => $created ) {
+			if ( (int) $created < $cutoff ) {
+				delete_option( self::OPTION_PREFIX . $token );
+				unset( $index[ $token ] );
+				$changed = true;
 			}
+		}
+
+		if ( $changed ) {
+			update_option( self::INDEX_OPTION, $index, false );
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: revisions, database cleanup, performance, wp cron, maintenance
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 1.6150
+Stable tag: 1.6148.2110
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://thisismyurl.com/thisismyurl-revision-reaper/

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,12 @@ I review PRs thoughtfully and appreciate well-tested contributions. Contributing
 
 == Changelog ==
 
+= 1.6149 =
+* Accessibility: the live-run progress bar now exposes `role="progressbar"` with `aria-valuenow/min/max` and a label, and the admin runner updates `aria-valuenow` in step with the visual width so screen-reader users hear progress during a destructive run.
+* Accessibility: the activity log is now a focusable live region (`role="log"`, `aria-live="assertive"`, `tabindex="0"`, label) so failures interrupt and keyboard users can scroll it.
+* Accessibility: marked the configuration layout table `role="presentation"`, associated the Revisions-to-Keep field with its label, and gave the Include Trash, Include Spam, and Enable Automation checkboxes programmatic names via `aria-labelledby`.
+* Accessibility: linked the backup-acknowledgement checkbox to the gated Run Now (Live) button with `aria-controls`.
+
 = 1.6148 =
 * Added WordPress 7 Abilities API support: the `thisismyurl-revision-reaper/clean` ability runs a full cleanup pass (revisions, trashed posts, spam comments, expired transients, table optimization) and returns per-category counts plus bytes reclaimed, with an optional `dry_run` preview. Guarded by the `manage_options` capability.
 * Extracted the shared cleanup routine into a single `TIMU_Revision_Reaper::run_cleanup()` method so the scheduled cron and the new ability funnel through one implementation.

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,10 @@ I review PRs thoughtfully and appreciate well-tested contributions. Contributing
 
 == Changelog ==
 
+= 1.6148 =
+* Added WordPress 7 Abilities API support: the `thisismyurl-revision-reaper/clean` ability runs a full cleanup pass (revisions, trashed posts, spam comments, expired transients, table optimization) and returns per-category counts plus bytes reclaimed, with an optional `dry_run` preview. Guarded by the `manage_options` capability.
+* Extracted the shared cleanup routine into a single `TIMU_Revision_Reaper::run_cleanup()` method so the scheduled cron and the new ability funnel through one implementation.
+
 = 1.6147 =
 * Unified plugin versioning to the x.Yddd calendar-version scheme.
 * Confirmed compatibility with WordPress 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: revisions, database cleanup, performance, wp cron, maintenance
 Requires at least: 6.4
 Tested up to: 7.0
 Requires PHP: 8.1
-Stable tag: 1.6147
+Stable tag: 1.6150
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Plugin URI: https://thisismyurl.com/thisismyurl-revision-reaper/
@@ -57,7 +57,7 @@ No. It targets revisions, trash, spam/unapproved comments, and expired transient
 Yes. Configure interval and run size in plugin settings.
 
 = Is this suitable for multisite? =
-The plugin loads and runs per-site on multisite (not network-activated as a single switch). Each site keeps its own settings, schedule, and pre-delete export directory under its own `wp-content/uploads/`. Multisite is not part of the formal test matrix yet — please test in a staging network before rolling to production. Network-wide reaping (one cron pass that walks every site) is on the roadmap and tracked on the GitHub issue list.
+The plugin loads and runs per-site on multisite (not network-activated as a single switch). Each site keeps its own settings, schedule, and pre-delete snapshots in its own options table. Multisite is not part of the formal test matrix yet — please test in a staging network before rolling to production. Network-wide reaping (one cron pass that walks every site) is on the roadmap and tracked on the GitHub issue list.
 
 == Support, Contributing & Sponsorship ==
 
@@ -90,6 +90,12 @@ I review PRs thoughtfully and appreciate well-tested contributions. Contributing
 
 
 == Changelog ==
+
+= 1.6150 =
+* Privacy: pre-delete snapshots (which can include comment author email and IP) are now stored as a non-autoloaded option in the database instead of a JSON file under `wp-content/uploads/`. The old file location was web-root on every server and its deny-all `.htaccess` was inert on nginx, so a guessable filename could expose the snapshot to an unauthenticated request. The options table is never web-served, closing that exposure on any web server.
+* Support: the scheduled-run email report now only sends when the run actually cleaned something, so a quiet weekly run no longer emails a "No items required cleaning" notice.
+* Performance: expired-transient cleanup now pre-counts only the expired pairs once instead of counting all transient-timeout rows both before and after core's `delete_expired_transients()`, removing two redundant full scans of the options table per run.
+* Docs: reconciled the changelog, `@since` tag, and readme so the Abilities API support is consistently attributed to 1.6148.
 
 = 1.6149 =
 * Accessibility: the live-run progress bar now exposes `role="progressbar"` with `aria-valuenow/min/max` and a label, and the admin runner updates `aria-valuenow` in step with the visual width so screen-reader users hear progress during a destructive run.

--- a/thisismyurl-revision-reaper.php
+++ b/thisismyurl-revision-reaper.php
@@ -905,24 +905,24 @@ class TIMU_Revision_Reaper {
                         <div class="postbox">
                             <h2 class="hndle"><span><?php esc_html_e( 'Configuration & Automation', 'thisismyurl-revision-reaper' ); ?></span></h2>
                             <div class="inside">
-                                <table class="form-table">
+                                <table class="form-table" role="presentation">
                                     <tr>
-                                        <th scope="row"><?php esc_html_e( 'Revisions to Keep', 'thisismyurl-revision-reaper' ); ?></th>
+                                        <th scope="row"><label for="rr-limit"><?php esc_html_e( 'Revisions to Keep', 'thisismyurl-revision-reaper' ); ?></label></th>
                                         <td><input type="number" name="rev_limit" id="rr-limit" value="<?php echo esc_attr( $current_limit ); ?>" class="small-text"></td>
                                     </tr>
                                     <tr>
-                                        <th scope="row"><?php esc_html_e( 'Include Trash', 'thisismyurl-revision-reaper' ); ?></th>
-                                        <td><input type="checkbox" name="include_trash" id="rr-trash" value="1" <?php checked( $auto_trash ); ?>></td>
+                                        <th scope="row" id="rr-trash-label"><?php esc_html_e( 'Include Trash', 'thisismyurl-revision-reaper' ); ?></th>
+                                        <td><input type="checkbox" name="include_trash" id="rr-trash" value="1" aria-labelledby="rr-trash-label" <?php checked( $auto_trash ); ?>></td>
                                     </tr>
                                     <tr>
-                                        <th scope="row"><?php esc_html_e( 'Include Spam', 'thisismyurl-revision-reaper' ); ?></th>
-                                        <td><input type="checkbox" name="include_spam" id="rr-spam" value="1" <?php checked( $auto_spam ); ?>></td>
+                                        <th scope="row" id="rr-spam-label"><?php esc_html_e( 'Include Spam', 'thisismyurl-revision-reaper' ); ?></th>
+                                        <td><input type="checkbox" name="include_spam" id="rr-spam" value="1" aria-labelledby="rr-spam-label" <?php checked( $auto_spam ); ?>></td>
                                     </tr>
                                     <tr><td colspan="2"><hr></td></tr>
                                     <tr>
-                                        <th scope="row"><?php esc_html_e( 'Enable Automation', 'thisismyurl-revision-reaper' ); ?></th>
+                                        <th scope="row" id="rr-schedule-label"><?php esc_html_e( 'Enable Automation', 'thisismyurl-revision-reaper' ); ?></th>
                                         <td>
-                                            <input type="checkbox" name="enable_schedule" value="1" <?php checked( $automation_enabled ); ?>>
+                                            <input type="checkbox" name="enable_schedule" id="rr-schedule" value="1" aria-labelledby="rr-schedule-label" <?php checked( $automation_enabled ); ?>>
                                             <?php if ( $next_run ) : ?>
                                                 <p class="description" style="color:#2271b1; font-weight:bold;">
                                                     <?php
@@ -995,7 +995,7 @@ class TIMU_Revision_Reaper {
                                     <input type="hidden" name="action" value="timu_rr_run">
                                     <p>
                                         <label>
-                                            <input type="checkbox" name="rr_backup_confirm" id="rr-backup-confirm" value="1">
+                                            <input type="checkbox" name="rr_backup_confirm" id="rr-backup-confirm" value="1" aria-controls="rr-live-run-btn">
                                             <?php esc_html_e( 'I understand a JSON snapshot will be written to uploads/revision-reaper/exports/ before deletion and I have verified my own backups are current.', 'thisismyurl-revision-reaper' ); ?>
                                         </label>
                                     </p>
@@ -1008,9 +1008,9 @@ class TIMU_Revision_Reaper {
                             <h2 class="hndle"><span><?php echo esc_html( $is_dry_run_active ? __( 'Simulation Log', 'thisismyurl-revision-reaper' ) : __( 'Live Activity Log', 'thisismyurl-revision-reaper' ) ); ?></span></h2>
                             <div class="inside">
                                 <div id="rr-progress-container" style="background:#f0f0f1; height:20px; border-radius:3px; border:1px solid #c3c4c7; margin-bottom:10px; overflow:hidden;">
-                                    <div id="rr-progress-bar" style="background:#2271b1; height:100%; width:0%;"></div>
+                                    <div id="rr-progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-label="<?php esc_attr_e( 'Cleanup progress', 'thisismyurl-revision-reaper' ); ?>" style="background:#2271b1; height:100%; width:0%;"></div>
                                 </div>
-                                <div id="rr-log" style="background:#f6f7f7; padding:10px; border:1px solid #dcdcde; height:200px; overflow-y:scroll; font-family:monospace;"></div>
+                                <div id="rr-log" role="log" aria-live="assertive" tabindex="0" aria-label="<?php esc_attr_e( 'Cleanup activity log', 'thisismyurl-revision-reaper' ); ?>" style="background:#f6f7f7; padding:10px; border:1px solid #dcdcde; height:200px; overflow-y:scroll; font-family:monospace;"></div>
                             </div>
                         </div>
                     </div>

--- a/thisismyurl-revision-reaper.php
+++ b/thisismyurl-revision-reaper.php
@@ -5,7 +5,7 @@
  * Plugin Name: This Is My URL - Revision Reaper
  * Plugin URI:  https://thisismyurl.com/thisismyurl-revision-reaper/
  * Description: Non-destructive database optimization with persistent settings, custom scheduling, and email reporting.
- * Version:     1.6147
+ * Version:     1.6148.2110
  * Requires at least: 6.4
  * Requires PHP: 8.1
  * Text Domain: thisismyurl-revision-reaper
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'TIMU_REVISION_REAPER_VERSION' ) ) {
-    define( 'TIMU_REVISION_REAPER_VERSION', '1.6150' );
+    define( 'TIMU_REVISION_REAPER_VERSION', '1.6148.2110' );
 }
 
 require_once __DIR__ . '/includes/class-exporter.php';

--- a/thisismyurl-revision-reaper.php
+++ b/thisismyurl-revision-reaper.php
@@ -27,6 +27,7 @@ if ( ! defined( 'TIMU_REVISION_REAPER_VERSION' ) ) {
 
 require_once __DIR__ . '/includes/class-exporter.php';
 require_once __DIR__ . '/includes/class-site-health.php';
+require_once __DIR__ . '/includes/abilities.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require_once __DIR__ . '/includes/class-cli.php';
@@ -143,49 +144,121 @@ class TIMU_Revision_Reaper {
             'include_spam'  => get_option( 'timu_rr_auto_spam', 0 ),
         );
         $email = get_option( 'timu_rr_report_email', get_option( 'admin_email' ) );
-        
-        $items = self::get_eligible_items( $settings );
-        $log = array();
 
-        // Pre-delete snapshot so a regretted scheduled run can be reconstructed
-        // from disk. Failure to write is logged but does not abort the run —
-        // the run itself uses trash, not force-delete (see class header).
-        if ( ! empty( $items ) ) {
-            $export_path = TIMU_Revision_Reaper_Exporter::snapshot_before_run( $items, (int) $settings['limit'] );
+        $report = self::run_cleanup( $settings );
+
+        // Send Email Report
+        if ( ! empty( $email ) ) {
+            $log     = $report['log'];
+            $subject = '[' . get_bloginfo( 'name' ) . '] Revision Reaper Automated Report';
+            $message = "The scheduled database cleanup has finished.\n\nItems Processed:\n" . ( ! empty( $log ) ? implode( "\n", $log ) : 'No items required cleaning.' );
+            wp_mail( $email, $subject, $message );
+        }
+    }
+
+    /**
+     * Perform a full cleanup pass and return structured counts plus ROI.
+     *
+     * This is the canonical, UI-agnostic cleanup routine. The scheduled-cron
+     * handler, the WP-CLI command, and the Abilities API all funnel through
+     * here so the deletion rules and ROI maths live in exactly one place.
+     *
+     * The run is non-destructive in the same sense the rest of the plugin is:
+     * trashed posts are force-deleted only once they have aged past
+     * EMPTY_TRASH_DAYS, spam comments are moved to the comment trash (not
+     * force-deleted), and a JSON snapshot is written before any row is touched.
+     *
+     * @param array $settings { limit, include_trash, include_spam, include_revisions }.
+     *                        include_revisions is optional and defaults to true
+     *                        (the historical behaviour); set it false to skip the
+     *                        revision sweep entirely.
+     * @param array $caps     Optional overrides forwarded to get_eligible_items().
+     * @param bool  $dry_run  When true, compute counts and ROI without deleting.
+     * @return array {
+     *     @type int    $revisions      Posts whose surplus revisions were reaped.
+     *     @type int    $trashed_posts  Trashed posts purged (aged past EMPTY_TRASH_DAYS).
+     *     @type int    $trash_skipped  Trashed posts skipped (not yet old enough).
+     *     @type int    $spam_comments  Spam comments moved to the comment trash.
+     *     @type int    $transients     Expired transient pairs removed.
+     *     @type int    $tables         Tables optimized.
+     *     @type int    $bytes_freed    Bytes reclaimed from reaped revision rows.
+     *     @type bool   $dry_run        Whether this was a preview run.
+     *     @type string $export         Snapshot file path, or '' when none was written.
+     *     @type array  $log            Human-readable per-step log lines.
+     * }
+     */
+    public static function run_cleanup( array $settings, array $caps = array(), $dry_run = false ) {
+        $dry_run = (bool) $dry_run;
+        $limit   = max( 0, (int) $settings['limit'] );
+        $items   = self::get_eligible_items( $settings, $caps );
+        $log     = array();
+        $export  = '';
+
+        // Revisions are swept by default; an explicit false opts out. We filter
+        // the eligible set rather than touch the shared scan so nothing excluded
+        // is ever snapshotted or deleted (mirrors the WP-CLI --include behaviour).
+        $include_revisions = ! array_key_exists( 'include_revisions', $settings ) || ! empty( $settings['include_revisions'] );
+        if ( ! $include_revisions ) {
+            $items = array_values( array_filter( $items, static function ( $item ) {
+                return 'revision' !== $item['type'];
+            } ) );
+        }
+
+        // Pre-delete snapshot so a regretted run can be reconstructed from
+        // disk. Skipped on a dry run — nothing is being removed to snapshot.
+        if ( ! $dry_run && ! empty( $items ) ) {
+            $export_path = TIMU_Revision_Reaper_Exporter::snapshot_before_run( $items, $limit );
             if ( $export_path ) {
-                $log[] = 'Pre-run export written: ' . wp_basename( $export_path );
+                $export = $export_path;
+                $log[]  = 'Pre-run export written: ' . wp_basename( $export_path );
             } else {
                 $log[] = 'WARNING: pre-run export failed to write.';
             }
         }
 
+        $counts = array(
+            'revisions'     => 0,
+            'trashed_posts' => 0,
+            'trash_skipped' => 0,
+            'spam_comments' => 0,
+        );
         $bytes_freed = 0;
 
         foreach ( $items as $item ) {
             if ( 'trash' === $item['type'] ) {
                 // Non-destructive: delegate to WP's trash lifecycle. WP itself
                 // empties trash items older than EMPTY_TRASH_DAYS via the
-                // wp_scheduled_delete cron — we never force-delete here.
+                // wp_scheduled_delete cron — we never force-delete the young.
                 if ( ! self::trash_post_eligible_for_purge( $item['id'] ) ) {
+                    $counts['trash_skipped']++;
                     continue;
                 }
-                wp_delete_post( $item['id'], false );
+                if ( ! $dry_run ) {
+                    wp_delete_post( $item['id'], false );
+                }
+                $counts['trashed_posts']++;
                 $log[] = "Trashed Post #{$item['id']} purged (older than EMPTY_TRASH_DAYS)";
             } elseif ( 'spam' === $item['type'] ) {
                 // Non-destructive: trash spam comments. Site owner can still
                 // recover from the Comments > Trash list before WP empties it.
-                wp_trash_comment( $item['id'] );
+                if ( ! $dry_run ) {
+                    wp_trash_comment( $item['id'] );
+                }
+                $counts['spam_comments']++;
                 $log[] = "Spam Comment #{$item['id']} moved to comment trash";
             } else {
                 $revisions = wp_get_post_revisions( $item['id'] );
-                $to_remove = array_slice( $revisions, $settings['limit'] );
+                $to_remove = array_slice( $revisions, $limit );
                 foreach ( $to_remove as $rev ) {
                     // Honest ROI: count actual bytes the row contributed
                     // before we drop it. Sum of post_content lengths is the
                     // dominant component on a revision.
                     $bytes_freed += strlen( (string) $rev->post_content );
-                    wp_delete_post_revision( $rev->ID );
+                    if ( ! $dry_run ) {
+                        wp_delete_post_revision( $rev->ID );
+                    }
                 }
+                $counts['revisions']++;
                 $log[] = "Reaped revisions for Post #{$item['id']}";
             }
         }
@@ -196,27 +269,61 @@ class TIMU_Revision_Reaper {
                 size_format( $bytes_freed )
             );
         }
-        
+
         // Expired transients live in wp_options (or sitemeta on multisite).
-        // The plugin marketed transient cleanup but never implemented it.
-        $expired_transients = self::delete_expired_transients();
-        if ( $expired_transients > 0 ) {
-            $log[] = sprintf( 'Deleted %d expired transient pairs.', (int) $expired_transients );
+        // Counting is inseparable from deletion in WP's helper, so a dry run
+        // reports a separately-measured eligible count instead.
+        $transients = $dry_run ? self::count_expired_transients() : self::delete_expired_transients();
+        if ( $transients > 0 ) {
+            $log[] = sprintf( 'Deleted %d expired transient pairs.', (int) $transients );
         }
 
         // Final database optimization (MyISAM tables only — InnoDB rebuilds
-        // on OPTIMIZE which is wasteful on a maintenance pass).
-        $optimized = self::optimize_wp_tables();
+        // on OPTIMIZE which is wasteful on a maintenance pass). No-op on a
+        // dry run; OPTIMIZE has no safe non-destructive preview.
+        $optimized = $dry_run ? 0 : self::optimize_wp_tables();
         if ( $optimized > 0 ) {
             $log[] = sprintf( 'Optimized %d tables.', (int) $optimized );
         }
 
-        // Send Email Report
-        if ( ! empty( $email ) ) {
-            $subject = '[' . get_bloginfo( 'name' ) . '] Revision Reaper Automated Report';
-            $message = "The scheduled database cleanup has finished.\n\nItems Processed:\n" . ( ! empty( $log ) ? implode( "\n", $log ) : "No items required cleaning." );
-            wp_mail( $email, $subject, $message );
-        }
+        return array(
+            'revisions'     => $counts['revisions'],
+            'trashed_posts' => $counts['trashed_posts'],
+            'trash_skipped' => $counts['trash_skipped'],
+            'spam_comments' => $counts['spam_comments'],
+            'transients'    => (int) $transients,
+            'tables'        => (int) $optimized,
+            'bytes_freed'   => $bytes_freed,
+            'dry_run'       => $dry_run,
+            'export'        => $export,
+            'log'           => $log,
+        );
+    }
+
+    /**
+     * Count expired transient pairs without deleting them.
+     *
+     * WP core's delete_expired_transients() returns void and always deletes,
+     * so a dry run needs its own read-only count of the same rows that helper
+     * would remove. Mirrors the LIKE clauses used in delete_expired_transients().
+     *
+     * @return int Number of expired transient *pairs* (value + timeout) eligible for removal.
+     */
+    public static function count_expired_transients() {
+        global $wpdb;
+
+        // Timeout rows whose stored expiry is in the past. Each timeout row
+        // pairs with one value row, so the timeout count is the pair count.
+        $now = time();
+
+        return (int) $wpdb->get_var( $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->options}
+             WHERE ( option_name LIKE %s OR option_name LIKE %s )
+               AND option_value < %d",
+            $wpdb->esc_like( '_transient_timeout_' ) . '%',
+            $wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+            $now
+        ) );
     }
 
     /**

--- a/thisismyurl-revision-reaper.php
+++ b/thisismyurl-revision-reaper.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'TIMU_REVISION_REAPER_VERSION' ) ) {
-    define( 'TIMU_REVISION_REAPER_VERSION', '1.6147' );
+    define( 'TIMU_REVISION_REAPER_VERSION', '1.6150' );
 }
 
 require_once __DIR__ . '/includes/class-exporter.php';
@@ -147,11 +147,21 @@ class TIMU_Revision_Reaper {
 
         $report = self::run_cleanup( $settings );
 
-        // Send Email Report
-        if ( ! empty( $email ) ) {
-            $log     = $report['log'];
+        // Only email when the run actually cleaned something. A weekly
+        // "No items required cleaning" notice is the top driver of "why is
+        // this plugin emailing me" support tickets, so a quiet run stays
+        // silent. We gate on the per-category counts rather than the log,
+        // because the log carries bookkeeping lines (pre-run export written,
+        // etc.) even on a run that removed no rows.
+        $cleaned = (int) $report['revisions']
+            + (int) $report['trashed_posts']
+            + (int) $report['spam_comments']
+            + (int) $report['transients']
+            + (int) $report['tables'];
+
+        if ( ! empty( $email ) && $cleaned > 0 ) {
             $subject = '[' . get_bloginfo( 'name' ) . '] Revision Reaper Automated Report';
-            $message = "The scheduled database cleanup has finished.\n\nItems Processed:\n" . ( ! empty( $log ) ? implode( "\n", $log ) : 'No items required cleaning.' );
+            $message = "The scheduled database cleanup has finished.\n\nItems Processed:\n" . implode( "\n", $report['log'] );
             wp_mail( $email, $subject, $message );
         }
     }
@@ -333,30 +343,23 @@ class TIMU_Revision_Reaper {
      * and we simply delegate to it — wrapping it here keeps the call site
      * legible and lets us return a count for the run report.
      *
-     * @return int Number of transient *pairs* (value + timeout) removed.
+     * We pre-count only the *expired* pairs (the rows core is about to remove)
+     * with a single scan via count_expired_transients(), rather than counting
+     * all timeout rows twice (before and after). That earlier before/after
+     * delta meant three full passes over the timeout rows per run — two of our
+     * own counts plus core's own scan — when one read of the rows-to-be-removed
+     * gives the same report number.
+     *
+     * @return int Number of expired transient *pairs* (value + timeout) removed.
      */
     public static function delete_expired_transients() {
-        global $wpdb;
-
-        // Pre-count so we can report something meaningful. WP's helper
-        // returns void, so we measure the option-row delta ourselves.
-        $before = (int) $wpdb->get_var(
-            "SELECT COUNT(*) FROM {$wpdb->options}
-             WHERE option_name LIKE '\\_transient\\_timeout\\_%'
-                OR option_name LIKE '\\_site\\_transient\\_timeout\\_%'"
-        );
+        $expired = self::count_expired_transients();
 
         if ( function_exists( 'delete_expired_transients' ) ) {
             delete_expired_transients( true );
         }
 
-        $after = (int) $wpdb->get_var(
-            "SELECT COUNT(*) FROM {$wpdb->options}
-             WHERE option_name LIKE '\\_transient\\_timeout\\_%'
-                OR option_name LIKE '\\_site\\_transient\\_timeout\\_%'"
-        );
-
-        return max( 0, $before - $after );
+        return $expired;
     }
 
     /**
@@ -996,7 +999,7 @@ class TIMU_Revision_Reaper {
                                     <p>
                                         <label>
                                             <input type="checkbox" name="rr_backup_confirm" id="rr-backup-confirm" value="1" aria-controls="rr-live-run-btn">
-                                            <?php esc_html_e( 'I understand a JSON snapshot will be written to uploads/revision-reaper/exports/ before deletion and I have verified my own backups are current.', 'thisismyurl-revision-reaper' ); ?>
+                                            <?php esc_html_e( 'I understand a JSON snapshot will be saved to the database before deletion and I have verified my own backups are current.', 'thisismyurl-revision-reaper' ); ?>
                                         </label>
                                     </p>
                                     <button type="submit" class="button button-primary" id="rr-live-run-btn" disabled><?php esc_html_e( 'Run Now (Live)', 'thisismyurl-revision-reaper' ); ?></button>

--- a/uninstall.php
+++ b/uninstall.php
@@ -35,3 +35,28 @@ $options = array(
 foreach ( $options as $option ) {
     delete_option( $option );
 }
+
+/**
+ * 3. Delete every pre-delete snapshot and its registry.
+ *
+ * Snapshots are stored as non-autoloaded options named
+ * `timu_rr_export_<token>`, tracked in the `timu_rr_export_index` registry.
+ * Walk the registry first, then sweep any orphaned snapshot rows the
+ * registry missed (e.g. a snapshot whose registry entry was lost).
+ */
+$export_index = get_option( 'timu_rr_export_index', array() );
+if ( is_array( $export_index ) ) {
+    foreach ( array_keys( $export_index ) as $token ) {
+        delete_option( 'timu_rr_export_' . $token );
+    }
+}
+delete_option( 'timu_rr_export_index' );
+
+global $wpdb;
+$orphans = $wpdb->get_col( $wpdb->prepare(
+    "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s",
+    $wpdb->esc_like( 'timu_rr_export_' ) . '%'
+) );
+foreach ( $orphans as $orphan ) {
+    delete_option( $orphan );
+}


### PR DESCRIPTION
WP 7 hardening pass — thisismyurl-revision-reaper.

Recommendation: **TEST** (net-new/mechanism change — activation + feature test before merge/tag).

Changes (4 commits):
- Add WP 7 Abilities API support
- Fix P0-5 + P1 a11y on destructive-run UI
- Fix P2 PII-on-disk (DB-backed snapshots) + email noise + transient scan + P3 version trinity
- Stamp release version 1.6148.2110

Audit + scorecard: clients/thisismyurl/plugin-line-hardening/HARDENING-AUDIT.md
All files php -l clean. Version stamped X.6148.2110 (Toronto).