### PR TITLE
esc_url() on admin_url() in action links

### DIFF
--- a/thisismyurl-revision-reaper.php
+++ b/thisismyurl-revision-reaper.php
@@ -128,7 +128,7 @@ class TIMU_Revision_Reaper {
 
     public static function add_plugin_action_links( $links ) {
         $custom_links = array(
-            '<a href="' . admin_url( 'tools.php?page=revision-reaper' ) . '">' . esc_html__( 'Settings', 'thisismyurl-revision-reaper' ) . '</a>',
+            '<a href="' . esc_url( admin_url( 'tools.php?page=revision-reaper' ) ) . '">' . esc_html__( 'Settings', 'thisismyurl-revision-reaper' ) . '</a>',
             '<a href="' . esc_url( 'https://github.com/sponsors/thisismyurl' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Sponsor', 'thisismyurl-revision-reaper' ) . '</a>',
         );
         return array_merge( $custom_links, $links );


### PR DESCRIPTION
## Summary

Plugin Check: bare admin_url() in href context needs esc_url() wrapper.

## Changes

Plugin Check (PHPCS) fixes — no behaviour changes to production functionality.

## Test plan

- [ ] Install on a WordPress test site and confirm plugin activates without errors
- [ ] Verify Plugin Check passes with no new warnings on the modified files
- [ ] Confirm existing functionality unchanged

_AI-assisted: fixes researched and applied with Claude Sonnet 4.6; reviewed by Christopher Ross._